### PR TITLE
Fixed Kryo inclusion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    implementation "com.esotericsoftware:kryo5:5.6.0"
+    implementation include("com.esotericsoftware:kryo5:5.6.0")
 
     compileOnly "org.projectlombok:lombok:${project.lombok_version}"
     annotationProcessor "org.projectlombok:lombok:${project.lombok_version}"


### PR DESCRIPTION
Kryo is now going to be included in the final jar. Before a user would've had to add
```gradle
implementation include("com.esotericsoftware:kryo5:5.6.0")
```
to `gradle.build` instead of just
```gradle
implementation "com.esotericsoftware:kryo5:5.6.0"
```